### PR TITLE
make libvirt::network::bridge param optional

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -33,7 +33,7 @@
 #    An array of interfaces to forwad
 #
 define libvirt::network (
-  $bridge,
+  $bridge             = '',
   $forward_mode       = 'bridge',
   $forward_dev        = undef,
   $forward_interfaces = [],

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -27,13 +27,19 @@
 #   * vlan_tag: VLAN tag for this portgroup.
 # [*autostart*]
 #   Wheter to start this network on boot or not. Defaults to true.
+# [*forward_dev*]
+#    The interface to forward, useful in bridge and route mode
+# [*forward_interfaces*]
+#    An array of interfaces to forwad
 #
 define libvirt::network (
   $bridge,
-  $forward_mode     = 'bridge',
-  $virtualport_type = undef,
-  $portgroups       = [],
-  $autostart        = true,
+  $forward_mode       = 'bridge',
+  $forward_dev        = undef,
+  $forward_interfaces = [],
+  $virtualport_type   = undef,
+  $portgroups         = [],
+  $autostart          = true,
 ) {
 
   include ::libvirt::params

--- a/templates/network.xml.erb
+++ b/templates/network.xml.erb
@@ -1,8 +1,14 @@
 <network>
   <name><%= @name %></name>
-  <% if @forward_mode -%>
-  <forward mode='<%= @forward_mode %>'/>
-  <% end -%>
+  <%- if @forward_mode -%>
+    <forward<%-if @forward_dev -%> dev='<%= @forward_dev -%>'<%-end-%> mode='<%= @forward_mode -%>'<%-if @forward_interfaces.empty? -%>/<%-end-%>>
+      <%- if !@forward_interfaces.empty? -%>
+        <%- @forward_interfaces.each do |dev| -%>
+          <interface dev='<%= dev -%>'/>
+        <%- end -%>
+      </forward>
+    <%- end -%>
+  <%- end -%>
   <% if @bridge -%>
   <bridge name='<%= @bridge %>'/>
   <% end -%>

--- a/templates/network.xml.erb
+++ b/templates/network.xml.erb
@@ -9,7 +9,7 @@
       </forward>
     <%- end -%>
   <%- end -%>
-  <% if @bridge -%>
+  <% if @bridge != '' -%>
   <bridge name='<%= @bridge %>'/>
   <% end -%>
   <% if @virtualport_type -%>


### PR DESCRIPTION
There is no need to force bridge parameter. Template was already correct with https://github.com/cirrax/puppet-libvirt/blob/master/templates/network.xml.erb#L12 conditional, but manifest was still requiring the bridge parameter.