### PR TITLE
Add support for libvirtd.conf config file through libvirtd_conf param

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Define a domain (VM):
       autostart      => true,
     }
 
+Configure libvirtd settings in libvirtd.conf file:
+
+    class { '::libvirtd':
+        libvirtd_conf => {
+            'listen_tcp' => 1,
+            'tcp_port'   => 16509,
+        }
+    }
 Complete documentation is included in puppet doc format in the
 manifest files.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,8 +2,9 @@
 #
 # Installs configuration files
 class libvirt::config (
-  $qemu_hook = $libvirt::qemu_hook,
-  $qemu_conf = $libvirt::qemu_conf,
+  $qemu_hook     = $libvirt::qemu_hook,
+  $qemu_conf     = $libvirt::qemu_conf,
+  $libvirtd_conf = $libvirt::libvirtd_conf,
 ) inherits libvirt {
 
   include ::libvirt::params
@@ -23,6 +24,17 @@ class libvirt::config (
       group   => 'root',
       mode    => '0600',
       content => template('libvirt/qemu.conf'),
+      notify  => Service['libvirtd'],
+    }
+  }
+
+  if ($libvirtd_conf != {}) {
+    file {"${libvirt::params::config_dir}/libvirtd.conf":
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => template('libvirt/libvirtd.conf'),
+      notify  => Service['libvirtd'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,12 +60,19 @@
 #   Default suspend_multiplier for migrating domains with the manage-domains
 #   script. This can be overriden on a per domain basis. The default is 5.
 #
+# [*libvirtd_conf*]
+#   Hash of key/value pairs you want to put in libvirtd.conf file.
+#
 # === Examples
 #
 #  class { 'libvirt':
-#    qemu_hook => 'drbd',
-#    qemu_conf => {
+#    qemu_hook     => 'drbd',
+#    qemu_conf     => {
 #     'vnc_listen' => '0.0.0.0'
+#    }
+#    libvirtd_conf => {
+#     'listen_tls' => '0',
+#     'tcp_port'   =>  '"12345"',
 #    }
 #  }
 #
@@ -88,6 +95,7 @@ class libvirt (
   $evacuation            = 'migrate',
   $max_job_time          = '120',
   $suspend_multiplier    = '5',
+  $libvirtd_conf         = {},
 ) inherits libvirt::params {
 
   Anchor['libvirt::begin'] -> Class['Libvirt::Install'] -> Class['Libvirt::Config'] -> Class['Libvirt::Service'] -> Anchor['libvirt::installed'] -> Anchor['libvirt::end']

--- a/templates/libvirtd.conf
+++ b/templates/libvirtd.conf
@@ -1,0 +1,20 @@
+#
+# This file is managed with puppet (class ::libvirt::config)
+#    do not edit manually.
+#
+# Master configuration file for the libvirtd service.
+# All settings described here are optional - if omitted, sensible
+# defaults are used.
+#
+# See https://github.com/libvirt/libvirt/blob/master/src/remote/libvirtd.conf
+# for possible values.
+<%- @libvirtd_conf.each do |key,value| -%>
+    <%- if ( value.is_a? Array ) -%>
+<%= key %> = ["<%= value.join('", "') %>"]
+   <%- elsif  (( Integer(value) and Integer(value) <= 9) rescue false) -%>
+<%= key %> = <%= value %>
+    <%- else -%>
+<%= key %> = "<%= value %>"
+    <%- end -%>
+<%- end -%>
+


### PR DESCRIPTION
Same as other PR for libvirtd.conf file.

Note : https://github.com/typhon-team/puppet-libvirt/blob/8914599d1cd6ce19394fc2180c269132f1898ee3/templates/libvirtd.conf#L14 is in purpose as the config file can have integer values for digits (^[0-9]$) and string value for numbers (don't blame me ;)).

 