### PR TITLE
Add owner/group/mode parameter for libvirt_pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,147 @@ Generates MAC addresses for all interfaces in the array which do not yet have an
 address specified. The MAC addresses are based on the domain name, network and
 portgroup.
 
+### Types
+
+#### libvirt_pool
+
+Manages libvirt pools
+
+Example :
+  libvirt_pool { 'default' :
+    ensure => absent
+  }
+
+  libvirt_pool { 'mydirpool' :
+    ensure    => present,
+    active    => true,
+    autostart => true,
+    type      => 'dir',
+    target    => '/tmp/mypool',
+  }
+
+  libvirt_pool { 'mydirpool2' :
+    ensure       => present,
+    active       => true,
+    autostart    => true,
+    type         => 'dir',
+    target       => '/tmp/mypool2',
+    target_owner => 107,
+    target_group => 107,
+    target_mode  => '0755',
+  }
+
+  libvirt_pool { 'vm_storage':
+    ensure    => 'present',
+    active    => 'true',
+    type      => 'logical',
+    sourcedev => ['/dev/sdb', '/dev/sdc'],
+    target    => '/dev/vg0'
+  }
+
+
+##### Properties
+
+The following properties are available in the `libvirt_pool` type.
+
+###### `ensure`
+
+Valid values: present, absent
+
+Manages the creation or the removal of a pool
+`present` means that the pool will be defined and created
+`absent` means that the pool will be purged from the system
+
+Default value: present
+
+###### `active`
+
+Valid values: `true`, `false`
+
+Whether the pool should be started.
+
+Default value: true
+
+###### `autostart`
+
+Valid values: `true`, `false`
+
+Whether the pool should be autostarted.
+
+Default value: false
+
+##### Parameters
+
+The following parameters are available in the `libvirt_pool` type.
+
+###### `name`
+
+Valid values: /^\S+$/
+
+namevar
+
+The pool name.
+
+###### `type`
+
+Valid values: dir, netfs, fs, logical, disk, iscsi, mpath, rbd, sheepdog
+
+The pool type.
+
+###### `sourcehost`
+
+Valid values: /^\S+$/
+
+The source host.
+
+###### `sourcepath`
+
+Valid values: /(\/)?(\w)/
+
+The source path.
+
+###### `sourcedev`
+
+Valid values: /(\/)?(\w)/
+
+The source device.
+
+###### `sourcename`
+
+Valid values: /^\S+$/
+
+The source name.
+
+###### `sourceformat`
+
+Valid values: auto, nfs, glusterfs, cifs
+
+The source format.
+
+###### `target`
+
+Valid values: /(\/)?(\w)/
+
+The target.
+
+###### `target_owner`
+
+Valid values: /^\S+$/
+
+The owner of the target dir or filesystem
+
+###### `target_group`
+
+Valid values: /^\S+$/
+
+The group of the target dir or filesystem
+
+###### `target_mode`
+
+Valid values: /^[0-7]{4}$/
+
+The mode of the target dir or filesystem
+
 ## Limitations
 
 Things currently not supported:

--- a/lib/puppet/provider/libvirt_pool/virsh.rb
+++ b/lib/puppet/provider/libvirt_pool/virsh.rb
@@ -174,10 +174,32 @@ Puppet::Type.type(:libvirt_pool).provide(:virsh) do
     end
 
     target = resource[:target]
+    targetOwner = resource[:target_owner]
+    targetGroup = resource[:target_group]
+    targetMode = resource[:target_mode]
     if target
       targetEl = pool.add_element 'target'
       targetPathEl = targetEl.add_element 'path'
       targetPathEl.add_text target
+
+      if (targetOwner || targetGroup || targetMode)
+        targetPermissionsEl = targetEl.add_element 'permissions'
+
+        if targetOwner
+          targetPermissionsOwnerEl = targetPermissionsEl.add_element 'owner'
+          targetPermissionsOwnerEl.add_text targetOwner.to_s
+        end
+
+        if targetGroup
+          targetPermissionsGroupEl = targetPermissionsEl.add_element 'group'
+          targetPermissionsGroupEl.add_text targetGroup.to_s
+        end
+
+        if targetMode
+          targetPermissionsModeEl = targetPermissionsEl.add_element 'mode'
+          targetPermissionsModeEl.add_text targetMode.to_s
+        end
+      end
     end
 
     return root.to_s

--- a/spec/types/libvirt_pool_spec.rb
+++ b/spec/types/libvirt_pool_spec.rb
@@ -18,6 +18,9 @@ describe 'libvirt_pool' do
     it { is_expected.to be_valid_type.with_parameters('sourcename') }
     it { is_expected.to be_valid_type.with_parameters('sourceformat') }
     it { is_expected.to be_valid_type.with_parameters('target') }
+    it { is_expected.to be_valid_type.with_parameters('target_owner') }
+    it { is_expected.to be_valid_type.with_parameters('target_group') }
+    it { is_expected.to be_valid_type.with_parameters('target_mode') }
 
   end
 


### PR DESCRIPTION
This commit adds support for managing the target permissions by
extending the libvirt_pool type with the target_(owner|group|mode)
parameters.

Fixes #13.