### PR TITLE
Drop Puppet 3 support, increase version req on concat to < 5.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
   repositories:
     "concat":
         repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
-        branch: '2.1.x'
+        ref: '4.2.0'
     "stdlib":
         repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ rvm:
         - 2.1.0
 script: bundle exec rake test
 env:
-        - PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes
-        - PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
         - PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES=yes
         - PUPPET_GEM_VERSION="~> 5.0" STRICT_VARIABLES=yes
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "cirrax-libvirt",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": "Cirrax GmbH",
   "license": "GPL-3.0",
   "summary": "Puppet module to install libvirt and create virtual domain configuration",
@@ -49,7 +49,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 5.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "cirrax-libvirt",
-  "version": "2.1.4",
+  "version": "2.1.3",
   "author": "Cirrax GmbH",
   "license": "GPL-3.0",
   "summary": "Puppet module to install libvirt and create virtual domain configuration",


### PR DESCRIPTION
There's no reason why concat has to be restricted to < 3.0.0. The interface of Concat 4.2.0 (latest) is compatible with the existing code. Leaving this restriction in-place causes conflicts with puppetlabs-tomcat, puppetlabs-postgresql and puppet-nginx (and others I'm sure).