### PR TITLE
Update Test Matrix for Ruby 2.3 and 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
         - 1.9.3
-        - 2.1.0
+        - 2.1.5
+        - 2.3.3
+        - 2.5.1
 script: bundle exec rake test
 env:
         - PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes
@@ -19,3 +21,13 @@ matrix:
                   env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES=yes
                 - rvm: 1.9.3
                   env: PUPPET_GEM_VERSION="~> 5.0" STRICT_VARIABLES=yes
+                - rvm: 2.1.5
+                  env: PUPPET_GEM_VERSION="~> 5.0" STRICT_VARIABLES=yes
+                - rvm: 2.3.3
+                  env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes
+                - rvm: 2.3.3
+                  env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+                - rvm: 2.5.1
+                  env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes
+                - rvm: 2.5.1
+                  env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes


### PR DESCRIPTION
* Ruby 1.9.3 .. Debian 7.0/Wheezy
+ Ruby 2.1.5 .. Debian 8.0/Jessie
+ Ruby 2.3.3 .. Debian 9.0/Stretch and Ubuntu 17.10/Artful Aardvark
+ Ruby 2.5.1 .. Debian 10.0/Buster and Ubuntu 18.04 LTS/Bionic Beaver