### PR TITLE
Add virtio-rng

### DIFF
--- a/templates/domain.xml.erb
+++ b/templates/domain.xml.erb
@@ -54,6 +54,9 @@ disk_src_attrs = {
     <memballoon model='virtio'>
       <alias name='balloon0'/>
     </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/random</backend>
+    </rng>
     <serial type='pty'>
       <target port='0'/>
     </serial>


### PR DESCRIPTION
Provides a paravirtual random number generator to virtual machines, to prevent entropy starvation in guests. 