### PR TITLE
params: jessie, stretch: use qemu-kvm instead of qemu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,11 +10,11 @@ class libvirt::params {
           $service_name           = 'libvirt-bin'
         }
         'jessie': {
-          $libvirt_package_names  = ['libvirt-daemon-system', 'qemu']
+          $libvirt_package_names  = ['libvirt-daemon-system', 'qemu-kvm']
           $service_name           = 'libvirtd'
         }
         'stretch': {
-          $libvirt_package_names  = ['libvirt-daemon-system', 'qemu']
+          $libvirt_package_names  = ['libvirt-daemon-system', 'qemu-kvm']
           $service_name           = 'libvirtd'
         }
         'trusty', 'xenial': {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -27,7 +27,7 @@ describe 'libvirt::install' do
     it { is_expected.to contain_package('libvirt-daemon-system')
       .with_ensure( 'installed' )
     }
-    it { is_expected.to contain_package('qemu')
+    it { is_expected.to contain_package('qemu-kvm')
       .with_ensure( 'installed' )
     }
   end
@@ -43,7 +43,7 @@ describe 'libvirt::install' do
     it { is_expected.to contain_package('libvirt-daemon-system')
       .with_ensure( 'actual' )
     }
-    it { is_expected.to contain_package('qemu')
+    it { is_expected.to contain_package('qemu-kvm')
       .with_ensure( 'actual' )
     }
   end

--- a/spec/classes/libvirt_spec.rb
+++ b/spec/classes/libvirt_spec.rb
@@ -12,7 +12,7 @@ describe 'libvirt' do
 
   let :default_params do
       { :service_name          => 'libvirtd',
-	:libvirt_package_names => ['libvirt-daemon-system', 'qemu'],
+	:libvirt_package_names => ['libvirt-daemon-system', 'qemu-kvm'],
 	:qemu_conf             => {},
 	:qemu_hook_packages    => {'drbd' => ['xmlstarlet','python-libvirt'], },
 	:create_networks       => {},


### PR DESCRIPTION
As with Ubuntu, Debian only needs qemu-kvm, not all of the qemu-related packages.