### PR TITLE
Allow managing service with main class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,14 @@
 #   Only set this if your setup differs from the packages provided by
 #   your distribution.
 #
+# [*service_ensure*]
+#   Whether the service should be running.
+#   Defaults to 'running'
+#
+# [*service_enable*]
+#   Whether the service should be enabled.
+#   Defaults to true
+#
 # [*libvirt_package_names*]
 #   Array of the libvirt packages to install.
 #   Defaults to $libvirt::params::libvirt_package_names
@@ -95,6 +103,8 @@
 #
 class libvirt (
   $service_name          = $libvirt::params::service_name,
+  $service_ensure        = 'running',
+  $service_enable        = true,
   $libvirt_package_names = $libvirt::params::libvirt_package_names,
   $qemu_conf             = {},
   $qemu_hook             = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,10 @@
 #   Whether the service should be enabled.
 #   Defaults to true
 #
+# [*manage_service*]
+#   Whether the service should be managed by this module.
+#   Defaults to true
+#
 # [*libvirt_package_names*]
 #   Array of the libvirt packages to install.
 #   Defaults to $libvirt::params::libvirt_package_names
@@ -105,6 +109,7 @@ class libvirt (
   $service_name          = $libvirt::params::service_name,
   $service_ensure        = 'running',
   $service_enable        = true,
+  $manage_service        = true,
   $libvirt_package_names = $libvirt::params::libvirt_package_names,
   $qemu_conf             = {},
   $qemu_hook             = undef,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,8 +18,8 @@
 #
 class libvirt::service(
   $service_name   = $libvirt::service_name,
-  $service_ensure = 'running',
-  $service_enable = true,
+  $service_ensure = $libvirt::service_ensure,
+  $service_enable = $libvirt::service_enable,
 ) inherits libvirt {
 
   service {'libvirtd':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,15 +16,22 @@
 #   Whether the service should be enabled.
 #   Defaults to true
 #
+# [*manage_service*]
+#   Whether the service should be managed at all.
+#   Defaults to true
+#
 class libvirt::service(
   $service_name   = $libvirt::service_name,
   $service_ensure = $libvirt::service_ensure,
   $service_enable = $libvirt::service_enable,
+  $manage_service = $libvirt::manage_service,
 ) inherits libvirt {
 
-  service {'libvirtd':
-    ensure => $service_ensure,
-    name   => $service_name,
-    enable => $service_enable,
+  if $manage_service {
+    service {'libvirtd':
+      ensure => $service_ensure,
+      name   => $service_name,
+      enable => $service_enable,
+    }
   }
 }

--- a/spec/classes/libvirt_spec.rb
+++ b/spec/classes/libvirt_spec.rb
@@ -12,14 +12,15 @@ describe 'libvirt' do
 
   let :default_params do
       { :service_name          => 'libvirtd',
-	:libvirt_package_names => ['libvirt-daemon-system', 'qemu'],
-	:qemu_conf             => {},
-	:qemu_hook_packages    => {'drbd' => ['xmlstarlet','python-libvirt'], },
-	:create_networks       => {},
-	:create_domains        => {},
-	:evacuation            => 'migrate',
-	:max_job_time          => '120',
-	:suspend_multiplier    => '5',
+        :manage_service        => true,
+        :libvirt_package_names => ['libvirt-daemon-system', 'qemu'],
+        :qemu_conf             => {},
+        :qemu_hook_packages    => {'drbd' => ['xmlstarlet','python-libvirt'], },
+        :create_networks       => {},
+        :create_domains        => {},
+        :evacuation            => 'migrate',
+        :max_job_time          => '120',
+        :suspend_multiplier    => '5',
         :uri_aliases           => [],
         :uri_default           => '',
         :default_conf          => {},
@@ -74,5 +75,15 @@ describe 'libvirt' do
     it { is_expected.to contain_libvirt__domain('mydom')
       .with_max_memory(2048)
     }
+  end
+
+  context 'with manage_service false' do
+    let :params do
+      default_params.merge(
+        :manage_service => false,
+      )
+    end
+    it_behaves_like 'libvirt shared examples'
+    it { is_expected.not_to contain_service('libvirtd') }
   end
 end


### PR DESCRIPTION
For a «conforming» profile/role setup, all settings should be settable in the main class, since we cannot pass through not-profile variables to the backing classes.

This PR allows setting the service ensure/enable parameters in the main class.