### PR TITLE
Enable configure libvirtd systemd (#32)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,12 +2,13 @@
 #
 # Installs configuration files
 class libvirt::config (
-  String  $qemu_hook    = $libvirt::qemu_hook,
-  Hash    $qemu_conf    = $libvirt::qemu_conf,
-  Array   $uri_aliases  = $libvirt::uri_aliases,
-  String  $uri_default  = $libvirt::uri_default,
-  Hash    $default_conf = $libvirt::default_conf,
-  String  $config_dir   = $libvirt::config_dir,
+  String  $qemu_hook        = $libvirt::qemu_hook,
+  Hash    $qemu_conf        = $libvirt::qemu_conf,
+  Hash    $libvirtd_conf    = $libvirt::libvirtd_conf,
+  Array   $uri_aliases      = $libvirt::uri_aliases,
+  String  $uri_default      = $libvirt::uri_default,
+  Hash    $default_conf     = $libvirt::default_conf,
+  String  $config_dir       = $libvirt::config_dir,
   Boolean $drop_default_net = $libvirt::drop_default_net,
 ) inherits libvirt {
 
@@ -26,6 +27,15 @@ class libvirt::config (
       group   => 'root',
       mode    => '0600',
       content => template('libvirt/qemu.conf.erb'),
+    }
+  }
+
+  if ($libvirtd_conf != {}) {
+    file {"${config_dir}/libvirtd.conf":
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+      content => template('libvirt/libvirtd.conf.erb'),
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,9 @@
 #   Hash of nwfilters to create with libvirt::nwfilter
 #   Defaults to {}
 #
+# [*libvirtd_conf*]
+#   Hash of key/value pairs you want to put in libvirtd.conf file.
+#
 # The following values are only useful together with the drbd qemu_hook in
 # setups of two redundant virtualization hosts synchronized over DRBD. They
 # have no effect if qemu_hook is not set to drbd.
@@ -136,6 +139,7 @@ class libvirt (
   Hash    $create_networks       = {},
   Hash    $create_domains        = {},
   Hash    $create_nwfilters      = {},
+  Hash    $libvirtd_conf         = {},
   String  $evacuation            = 'migrate',
   String  $max_job_time          = '120',
   String  $suspend_multiplier    = '5',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -11,11 +11,11 @@ describe 'libvirt::config' do
   end
 
   let :default_params do
-      { :qemu_conf    => {},
+      { :qemu_conf     => {},
         :libvirtd_conf => {},
-        :uri_aliases  => [],
-        :uri_default  => '',
-        :default_conf => {},
+        :uri_aliases   => [],
+        :uri_default   => '',
+        :default_conf  => {},
       }
   end
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -12,6 +12,7 @@ describe 'libvirt::config' do
 
   let :default_params do
       { :qemu_conf    => {},
+        :libvirtd_conf => {},
         :uri_aliases  => [],
         :uri_default  => '',
         :default_conf => {},

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -63,6 +63,29 @@ describe 'libvirt::config' do
     }
   end
 
+  context 'with libvirtd.conf' do
+    let :params do
+      default_params.merge(
+        :libvirtd_conf => {
+          'string'  => 'test',
+          'integer' => 2,
+          'int_str' => '"2"',
+          'array'   => ['A','B']
+        },
+      )
+    end
+    it_behaves_like 'libvirt::config shared examples'
+    it { is_expected.to contain_file('/etc/libvirt/libvirtd.conf')
+      .with_owner('root')
+      .with_group('root')
+      .with_mode('0600')
+      .with_content(/^string = "test"$/)
+      .with_content(/^integer = 2$/)
+      .with_content(/^int_str = "2"$/)
+      .with_content(/^array = \["A", "B"\]$/)
+    }
+  end
+
   context 'with uri_aliases' do
     let :params do
       default_params.merge(

--- a/spec/classes/libvirt_spec.rb
+++ b/spec/classes/libvirt_spec.rb
@@ -18,6 +18,7 @@ describe 'libvirt' do
         :qemu_hook_packages    => {'drbd' => ['xmlstarlet','python-libvirt'], },
         :create_networks       => {},
         :create_domains        => {},
+        :libvirtd_conf         => {},
         :evacuation            => 'migrate',
         :max_job_time          => '120',
         :suspend_multiplier    => '5',

--- a/templates/libvirtd.conf.erb
+++ b/templates/libvirtd.conf.erb
@@ -1,0 +1,19 @@
+#
+# This file is managed with puppet (class ::libvirt::config)
+#    do not edit manually.
+#
+# Master configuration file for the libvirtd daemon.
+# All settings described here are optional - if omitted, sensible
+# defaults are used.
+#
+# See https://github.com/libvirt/libvirt/blob/master/src/remote/libvirtd.conf
+# for possible values.
+<%- @libvirtd_conf.each do |key,value| -%>
+    <%- if ( value.is_a? Array ) -%>
+<%= key %> = ["<%= value.join('", "') %>"]
+   <%- elsif  ( Integer(value) rescue false ) or ( !!(value =~ /^".*"$/) ) -%>
+<%= key %> = <%= value %>
+    <%- else -%>
+<%= key %> = "<%= value %>"
+    <%- end -%>
+<%- end -%>


### PR DESCRIPTION
I took `qemu_conf` as an example. The only thing different than `qemu_conf` is the parameters name and `or ( !!(value =~ /^".*"$/) )` in it's template.

This allows to configure double quoted integers necessary for the options 'tls_port', 'tcp_port', 'unix_sock_ro_perms', 'unix_sock_rw_perms', and 'unix_sock_admin_perms'.

The port options allow numbers and service names, so their value is expected as string by libvirtd.

Hiera example:
   
    libvirt::libvirtd_conf:
      tcp_port: '"16509"'
      unix_sock_ro_perms: '"0770"'
