### PR TITLE
add dns_enable parameter to network define

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -38,6 +38,8 @@
 #    Optional dhcp range start
 # @param dhcp_end
 #    Optional dhcp range end
+# @param dns_enable
+#    Set this to 'no' to disable the DNS service. Leave undefined otherwise.
 #
 define libvirt::network (
   String           $ensure             = 'present',
@@ -52,6 +54,7 @@ define libvirt::network (
   Optional[String] $ip_netmask         = undef,
   Optional[String] $dhcp_start         = undef,
   Optional[String] $dhcp_end           = undef,
+  Optional[String] $dns_enable         = undef,
 ) {
 
   include ::libvirt

--- a/templates/network.xml.erb
+++ b/templates/network.xml.erb
@@ -21,6 +21,9 @@
     <%- end -%>
   </ip>
   <%- end -%>
+  <%- if @dns_enable -%>
+  <dns enable='<%= @dns_enable %>'/>
+  <%- end -%>
   <%- if @virtualport_type -%>
   <virtualport type='<%= @virtualport_type %>'/>
   <%- end -%>


### PR DESCRIPTION
This PR enables the option to disable the default dnsmasq dns service created by libvirt for the defined/created network.

Libvirt documentation quote:

> The dns element can have an optional enable attribute Since 2.2.0. If enable is "no", then no DNS server will be setup by libvirt for this network (and any other configuration in <dns> will be ignored). If enable is "yes" or unspecified (including the complete absence of any <dns> element) then a DNS server will be setup by libvirt to listen on all IP addresses specified in the network's configuration. 

[libvirt network documentation](https://libvirt.org/formatnetwork.html#elementsAddress)

In our usecase all guest use another dns service then the one provided by libvirt. Therefore we would like to disable the dns service in the libvirt network definition. This will also free up the binding on port 53, which allows us the run our own dns service for the specified network if needed.