### PR TITLE
add mtu parameter to network define

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -40,6 +40,8 @@
 #    Optional dhcp range end
 # @param dns_enable
 #    Set this to 'no' to disable the DNS service. Leave undefined otherwise.
+# @param mtu
+#    Set a custom mtu value. Default is 1500.
 #
 define libvirt::network (
   String           $ensure             = 'present',
@@ -55,6 +57,7 @@ define libvirt::network (
   Optional[String] $dhcp_start         = undef,
   Optional[String] $dhcp_end           = undef,
   Optional[String] $dns_enable         = undef,
+  Optional[Integer] $mtu               = undef,
 ) {
 
   include ::libvirt

--- a/templates/network.xml.erb
+++ b/templates/network.xml.erb
@@ -12,6 +12,9 @@
   <%- if @bridge != '' -%>
   <bridge name='<%= @bridge %>'/>
   <%- end -%>
+  <%- if @mtu -%>
+  <mtu size='<%= @mtu %>'/>
+  <%- end -%>
   <%- if @ip_address and @ip_netmask -%>
   <ip address='<%= @ip_address %>' netmask='<%= @ip_netmask %>'>
     <%- if @dhcp_start and @dhcp_end -%>


### PR DESCRIPTION
This PR enables the option set a custom mtu value for the defined/created network.

Libvirt documentation quote:

> The size attribute of the mtu element specifies the Maximum Transmission Unit (MTU) for the network. Since 3.1.0. In the case of a libvirt-managed network (one with forward mode of nat, route, open, or no forward element (i.e. an isolated network), this will be the MTU assigned to the bridge device when libvirt creates it, and thereafter also assigned to all tap devices created to connect guest interfaces. Network types not specifically mentioned here don't support having an MTU set in the libvirt network config. If mtu size is unspecified, the default setting for the type of device being used is assumed (usually 1500). 