### PR TITLE
fix spurious space in disk bus parameter value

### DIFF
--- a/templates/domain/device_disk.epp
+++ b/templates/domain/device_disk.epp
@@ -5,7 +5,7 @@
     | -%>
     <disk type='<%= $disk['type'] %>' device='<%= $disk['device'] %>'>
       <source <% $disk_src_attrs[$disk['type']].each | $attr | { -%><%= $attr %>='<%= $disk['source'][$attr] %>' <% } -%>/>
-      <target dev='vd<%= $ind %>' bus='<% if $disk.has_key('bus') { %><%= $disk['bus'] %><% } else { %><%= virtio %> <% } %>'/>
+      <target dev='vd<%= $ind %>' bus='<%= $disk.dig('bus').lest || { 'virtio' } %>'/>
     <%- if $disk.has_key('driver') { -%>
       <driver <% $disk['driver'].each |$attr| { -%><%= $attr[0] %>='<%= $attr[1] %>' <% } -%>/>
     <%- } else { -%>


### PR DESCRIPTION
Both the dig() and lest() functions appeared in Puppet 4.5, so should
be fine to use.

This fixes issue #47.