### PR TITLE
add hiera layer for architecture specific settings

### DIFF
--- a/data/Debian/default.yaml
+++ b/data/Debian/default.yaml
@@ -1,4 +1,5 @@
 ---
+# Debian/default.yaml
 # defaults for Debian Operating system
 
 libvirt::libvirt_package_names:

--- a/data/Ubuntu/14.04.yaml
+++ b/data/Ubuntu/14.04.yaml
@@ -1,5 +1,6 @@
 ---
-# Defaults for Ubuntu 16.04 LTS (Xenial Xerus)
+# Ubuntu/14.04.yaml
+# Defaults for Ubuntu 14.04 LTS (Trusty Tahr)
 
 libvirt::libvirt_package_names:
   - 'libvirt-bin'

--- a/data/Ubuntu/16.04.yaml
+++ b/data/Ubuntu/16.04.yaml
@@ -1,5 +1,6 @@
 ---
-# Defaults for Ubuntu 14.04 LTS (Trusty Tahr)
+# Ubuntu/16.04.yaml
+# Defaults for Ubuntu 16.04 LTS (Xenial Xerus)
 
 libvirt::libvirt_package_names:
   - 'libvirt-bin'

--- a/data/Ubuntu/default.yaml
+++ b/data/Ubuntu/default.yaml
@@ -1,4 +1,5 @@
 ---
+# Ubuntu/default.yaml
 # Defaults for Ubuntu
 
 libvirt::libvirt_package_names:

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,11 +6,14 @@ defaults:
   data_hash: 'yaml_data'
 
 hierarchy:
+  - name: 'Major Version architecture specific'
+    path: '%{facts.os.name}/%{facts.os.release.major}_%{facts.os.architecture}.yaml'
+
   - name: 'Major Version'
-    path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
+    path: '%{facts.os.name}/%{facts.os.release.major}.yaml'
 
   - name: 'Distribution Name'
-    path: '%{facts.os.name}.yaml'
+    path: '%{facts.os.name}/default.yaml'
 
   - name: 'Operating System Family'
     path: '%{facts.os.family}-family.yaml'


### PR DESCRIPTION
Newest Debian/Ubuntu versions using virtual packages for
qemu-kvm. Since usually you want to install the package
corresponding your architecture we introduce
a architecture specific hiera layer.

To avoid to many files in the root directory, we move
the OS specific packages in directories. (not the family !)

also see #59 and #60