### PR TITLE
Fixed Debian bullseye release number

### DIFF
--- a/data/Debian/11.yaml
+++ b/data/Debian/11.yaml
@@ -1,0 +1,9 @@
+---
+# Debian/12.yaml
+#
+# Debian bullseye defaults
+
+libvirt::qemu_hook_packages:
+  drbd:
+    - 'xmlstarlet'
+    - 'python3-libvirt'

--- a/data/Debian/11.yaml
+++ b/data/Debian/11.yaml
@@ -1,5 +1,5 @@
 ---
-# Debian/12.yaml
+# Debian/11.yaml
 #
 # Debian bullseye defaults
 

--- a/data/Debian/11_amd64.yaml
+++ b/data/Debian/11_amd64.yaml
@@ -1,0 +1,8 @@
+---
+# Debian/12_amd64.yaml
+#
+# defaults for Debian bullseye amd64 architecture
+
+libvirt::libvirt_package_names:
+  - 'libvirt-daemon-system'
+  - 'qemu-system-x86'

--- a/data/Debian/11_amd64.yaml
+++ b/data/Debian/11_amd64.yaml
@@ -1,5 +1,5 @@
 ---
-# Debian/12_amd64.yaml
+# Debian/11_amd64.yaml
 #
 # defaults for Debian bullseye amd64 architecture
 

--- a/data/Debian/12.yaml
+++ b/data/Debian/12.yaml
@@ -1,7 +1,7 @@
 ---
 # Debian/12.yaml
 #
-# Debian bullseye defaults
+# Debian bookworm defaults
 
 libvirt::qemu_hook_packages:
   drbd:

--- a/data/Debian/12_amd64.yaml
+++ b/data/Debian/12_amd64.yaml
@@ -1,7 +1,7 @@
 ---
 # Debian/12_amd64.yaml
 #
-# defaults for Debian bullseye amd64 architecture
+# defaults for Debian bookworm amd64 architecture
 
 libvirt::libvirt_package_names:
   - 'libvirt-daemon-system'


### PR DESCRIPTION
This PR added 11.yaml and 11_amd64.yaml for Debian bullseye to fix architecture-specific qemu package name. release 12 is named bookworm.