### PR TITLE
Fix error in Libvirt::Net::Forward definition

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2256,7 +2256,7 @@ Struct[{
           }]],
           ipv6 => Optional[Enum['yes']],
     }]],
-    interfaces => Optional[Array[Struct[{
+    interface => Optional[Array[Struct[{
             dev => String[1],
     }]]],
     pf => Optional[Struct[{

--- a/types/net/forward.pp
+++ b/types/net/forward.pp
@@ -14,7 +14,7 @@ type Libvirt::Net::Forward = Struct[{
           }]],
           ipv6 => Optional[Enum['yes']],
     }]],
-    interfaces => Optional[Array[Struct[{
+    interface => Optional[Array[Struct[{
             dev => String[1],
     }]]],
     pf => Optional[Struct[{


### PR DESCRIPTION
Hi,

I ran into the following error while attempting to fully define a network after adding the `interfaces => [ ... ]` option

```
Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Method call, block parameter 'b' expects a value of type String or Integer, got Tuple (file: [...]/modules/libvirt/templates/network/sub-element.xml.epp, line: 12, column: 34) [...]
```

The issue can be reproduced with the following:

```puppet
include libvirt

$forward_network = 'ens192'

libvirt::network { 'virbr-test':
    ensure    => present,
    autostart => true,
    bridge    => {
      name  => 'virbr-test',
      stp   => 'on',
      delay => 0,
    },
    dns       => {
      enable            => 'yes',
      forwardPlainNames => 'no',
      forwarder         => [{ addr => '1.1.1.1' }],
    },
    forward   => {
      mode       => 'nat',
      dev        => $forward_network,
      interfaces => [{ dev => $forward_network }], # <-- adding this caused the failure
      nat        => {
        port => {
          start => 1024,
          end   => 65535,
        },
      },
    },
    ips       => [{
        address => '192.168.0.1',
        netmask => '255.255.255.0',
        dhcp    => {
          range => [{
              start => '192.168.0.2',
              end   => '192.168.0.254',
          }],
          host  => [
            {
              mac  => '52:54:00:00:00:01',
              ip   => '192.168.0.2',
              name => 'test-vm-1',
            }
          ],
        },
    }],
    port      => { isolated => 'yes' },
    template  => 'generic',
  }
```

Diagnosing further, the tuple value being provided for `$b` in the template was the tuple `[{dev => 'ens192'}]`. A bit of poking revealed the use of `interfaces` when the libvirt XML itself (and therefore `libvirt::network_tree`, and therefore the attribute/element mapping) use `interface`.

After applying this patch and updating the XML definition above (`s/interfaces/interface/`), the network is correctly created and configured.