### PR TITLE
Delete the connections attribute on forward/interface elements

### DIFF
--- a/lib/puppet/provider/libvirt_network/virsh.rb
+++ b/lib/puppet/provider/libvirt_network/virsh.rb
@@ -93,6 +93,9 @@ Puppet::Type.type(:libvirt_network).provide(:virsh) do
     xml.root.elements.delete('//mac')
     # remove the connections
     xml.root.attributes.delete('connections')
+    xml.root.elements.each("//forward[@mode='passthrough']/interface") do |el|
+      el.attributes.delete('connections');
+    end
     formatter = REXML::Formatters::Pretty.new(2)
     formatter.compact = true
     output = ''.dup

--- a/lib/puppet/provider/libvirt_network/virsh.rb
+++ b/lib/puppet/provider/libvirt_network/virsh.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:libvirt_network).provide(:virsh) do
     xml.root.elements.delete('//mac')
     # remove the connections
     xml.root.attributes.delete('connections')
-    xml.root.elements.each("//forward[@mode='passthrough']/interface") do |el|
+    xml.root.elements.each("//forward/interface[@connections]") do |el|
       el.attributes.delete('connections');
     end
     formatter = REXML::Formatters::Pretty.new(2)

--- a/lib/puppet/provider/libvirt_network/virsh.rb
+++ b/lib/puppet/provider/libvirt_network/virsh.rb
@@ -93,8 +93,8 @@ Puppet::Type.type(:libvirt_network).provide(:virsh) do
     xml.root.elements.delete('//mac')
     # remove the connections
     xml.root.attributes.delete('connections')
-    xml.root.elements.each("//forward/interface[@connections]") do |el|
-      el.attributes.delete('connections');
+    xml.root.elements.each('//forward/interface[@connections]') do |el|
+      el.attributes.delete('connections')
     end
     formatter = REXML::Formatters::Pretty.new(2)
     formatter.compact = true


### PR DESCRIPTION
In the live XML definition of a network, Libvirt can add the connections attributes to the interface.
Removing it avoid the network to be redefine when an interface is used by a virtual domain.