### PR TITLE
Human readable diff in case of changes and correct sort for portgroups

### DIFF
--- a/lib/puppet/provider/libvirt_network/virsh.rb
+++ b/lib/puppet/provider/libvirt_network/virsh.rb
@@ -96,7 +96,16 @@ Puppet::Type.type(:libvirt_network).provide(:virsh) do
     formatter = REXML::Formatters::Pretty.new(2)
     formatter.compact = true
     output = ''.dup
-    formatter.write(recursive_sort(xml.root), output)
+
+    xml = recursive_sort(xml.root)
+    sorted_portgroups = xml.root.get_elements('//portgroup').sort_by { |obj| obj.attributes['name'] }
+
+    REXML::XPath.match(xml, '//portgroup').each(&:remove)
+    sorted_portgroups.each do |pg|
+      xml.root.add_element pg
+    end
+
+    formatter.write(xml.root, output)
     output
   end
 

--- a/lib/puppet/type/libvirt_network.rb
+++ b/lib/puppet/type/libvirt_network.rb
@@ -46,6 +46,22 @@ Puppet::Type.newtype(:libvirt_network) do
       raise ArgumentError, 'content needs to be a XML string' unless value.is_a?(String)
     end
 
+    def change_to_s(current, desire)
+      if @resource[:show_diff]
+        current_exp = Tempfile.new("current", "/tmp").open
+        current_exp.write(current.to_s)
+        current_exp.close
+        current_path = current_exp.path
+        desire_exp = Tempfile.new("desire", "/tmp").open
+        desire_exp.write(desire.to_s)
+        desire_exp.close
+        desire_path = desire_exp.path
+        system "diff -u #{current_path} #{desire_path}"
+      else
+        '{md5}' + Digest::MD5.hexdigest(current.to_s) + " to: " + '{md5}' + Digest::MD5.hexdigest(desire.to_s)
+      end
+    end
+
     def should_to_s(value)
       if @resource[:show_diff]
         ":\n" + value + "\n"


### PR DESCRIPTION
Hi,
First of all, I would like to thank you for the module.
I found that the module may add false positive notice events/messages on a puppet agent side.
It is a reproducible case.
As an example I added one more portgroup for the network configuration via yaml and in parallel I added a new portgroup on the host via `virsh net-update`. Starting from that point I see notices every time I run `puppet agent` on a client.
The false positives are gone as soon as I do `virsh net-destroy && virst net-start` (as an example) which is not bad, but I prefer to use `virsh net-update` mechanism because it won't interrupt the guest's network.

Also, I found the diff in a way like provided below:
```
Info: Applying configuration version 'XXX_YYY'
--- /tmp/current20240208-2398021-tnw8xs 2024-02-08 15:00:34.873488194 +0000
+++ /tmp/desire20240208-2398021-xhp6ng  2024-02-08 15:00:34.873488194 +0000
@@ -5,8 +5,10 @@
   <virtualport type='openvswitch'/>
   <portgroup name='EXAMPLE_VLAN'>
     <vlan trunk='yes'>
+      <tag id='72'/>
       <tag id='114'/>
       <tag id='212'/>
+      <tag id='0' nativeMode='untagged'/>
     </vlan>
   </portgroup>
   <portgroup name='EXAMPLE_VLAN2'>
Notice: /**/content: false (corrective)
```
more human-readable and it provides an idea about what is different between the current state and the state in Puppet repo.

Thanks!