### PR TITLE
Add possibility to create a VM in bridged network mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ libvirt::domain { 'my-domain':
 ```
 	
 Define a domain (VM) with a bridged network:
-*the network device must exists*
+*the network device must exist*
 ```
     libvirt::domain { 'my-domain':
       devices_profile => 'default',

--- a/README.md
+++ b/README.md
@@ -151,6 +151,36 @@ libvirt::domain { 'my-domain':
   autostart       => true,
 }
 ```
+	
+Define a domain (VM) with a bridged network:
+*the network device must exists*
+```
+    libvirt::domain { 'my-domain':
+      devices_profile => 'default',
+      dom_profile     => 'default',
+      boot            => 'hd',
+      domconf         => { memory => { values => '2048', attrs => { unit => 'MiB' }}},
+      disks           => [{'type' => 'block',
+                           'device' => 'disk',
+                           'source' => {'dev' => '/dev/vm-pool/my-domain.img'},
+                           },
+                          {'type'   => 'file',
+                           'device' => 'disk',
+                           'source' => {'dev' => '/var/lib/libvirt/images/my-disk.qcow2'},
+                           'bus'    => 'virtio',
+                           'driver' => {'name'  => 'qemu',
+                                        'type'  => 'qcow2',
+                                        'cache' => 'none',
+                                        },
+                          ],
+      interfaces      => [{
+		  'network' => virbr0', 
+		  'bridge_network' => true,
+		  },
+		  ],
+      autostart       => true,
+    }
+```
 
 Define a storage pool:
 

--- a/templates/domain/device_interface.epp
+++ b/templates/domain/device_interface.epp
@@ -1,7 +1,11 @@
 <%- |  Libvirt::Domain::Interface   $iface,
        String $boot,
     | -%>
+<%- if $iface['bridge_network'] and $iface['bridge_network'] == true { -%>
+    <interface type='bridge'>
+<%- } else { -%>
     <interface type='network'>
+<%- } -%>
 <%- if 'mac' in $iface { -%>
       <mac address='<%= $iface['mac'] %>'/>
 <%- } -%>
@@ -22,7 +26,11 @@
       </filterref>
    <%- } -%>
 <%- } -%>
+    <%- if $iface['bridge_network'] and $iface['bridge_network'] == true { -%>
+      <source bridge='<%= $iface['network'] %>'/>
+    <%- } else { -%>
       <source network='<%= $iface['network'] %>'<% if 'portgroup' in $iface { %> portgroup='<%= $iface['portgroup'] %>'<% } %>/>
+    <%- } -%>
       <model type='<% if 'type' in $iface { %><%= $iface['type'] %><% }else{ %>virtio<% } %>'/>
 <%- if $boot == 'per-device' and 'boot_order' in $iface { -%>
       <boot order='<%= $iface['boot_order'] %>'/>

--- a/types/domain/interface.pp
+++ b/types/domain/interface.pp
@@ -14,5 +14,6 @@ type Libvirt::Domain::Interface = Struct[{
             ]],
         }],
     ]],
-    boot_order => Optional[Integer],
+    boot_order     => Optional[Integer],
+    bridge_network => Optional[Boolean],
 }]


### PR DESCRIPTION
After problems with nftables and libvirtd, i talked with @bastelfreak and we talked about managing the network with systemd-networkd and bridge VMs directly to the systemd-networkd managed bridge.

It was not possible with the current state of this module, so i added an optional setting to create a bridged interface