### PR TITLE
Add possibility to create additional network types on VM (including bridged network mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,36 @@ libvirt::domain { 'my-domain':
   autostart       => true,
 }
 ```
+	
+Define a domain (VM) with a bridged network:
+*the network device must exists*
+```
+    libvirt::domain { 'my-domain':
+      devices_profile => 'default',
+      dom_profile     => 'default',
+      boot            => 'hd',
+      domconf         => { memory => { values => '2048', attrs => { unit => 'MiB' }}},
+      disks           => [{'type' => 'block',
+                           'device' => 'disk',
+                           'source' => {'dev' => '/dev/vm-pool/my-domain.img'},
+                           },
+                          {'type'   => 'file',
+                           'device' => 'disk',
+                           'source' => {'dev' => '/var/lib/libvirt/images/my-disk.qcow2'},
+                           'bus'    => 'virtio',
+                           'driver' => {'name'  => 'qemu',
+                                        'type'  => 'qcow2',
+                                        'cache' => 'none',
+                                        },
+                          ],
+      interfaces      => [{
+		  'network' => virbr0', 
+		  'bridge_network' => true,
+		  },
+		  ],
+      autostart       => true,
+    }
+```
 
 Define a storage pool:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ libvirt::domain { 'my-domain':
 ```
 	
 Define a domain (VM) with a bridged network:
-*the network device must exists*
+*the network device must exist*
 ```
     libvirt::domain { 'my-domain':
       devices_profile => 'default',

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ libvirt::domain { 'my-domain':
                                     'cache' => 'none',
                                     },
                       ],
-  interfaces      => [{'network' => 'net-simple'},],
+  interfaces      => [{'source' => {'network' => 'net-simple'}}],
   autostart       => true,
 }
 ```
@@ -175,11 +175,9 @@ Define a domain (VM) with a bridged network:
                                         'cache' => 'none',
                                         },
                           ],
-      interfaces      => [{
-		  'network' => virbr0', 
-		  'bridge_network' => true,
-		  },
-		  ],
+      interfaces      => [{ 'interface_type => 'bridge',
+                            'source'        => { 'bridge' => virbr0', },
+		         }],
       autostart       => true,
     }
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -827,6 +827,9 @@ at all. The hashes support the following keys:
  * boot_order:  Integer starting at 1 for the highest priority (shared with
                 interfaces).
 
+Hint: if a special configuration is not possible using this parameter, you can use the
+      $devices or $additionadevices parameter which make any configuration libvirt supports possible
+
 Default value: `[]`
 
 ##### <a name="-libvirt--domain--interfaces"></a>`interfaces`
@@ -836,14 +839,26 @@ Data type: `Array[Libvirt::Domain::Interface]`
 Array of hashes defining the network interfaces of this domain. Defaults to
 no network interfaces.
 The hashes support the following keys:
-  * mac:        MAC address of the interface. Without a mac key, a random
-                address will be assigned by libvirt. The MAC address should
-                start with 52:54:00.
-  * network:    libvirt network to attach to (mandatory).
-  * portgroup:  portgroup to attach to (optional).
-  * type:       Type of network card. Defaults to 'virtio'.
-  * boot_order: Integer starting at 1 for the highest priority (shared with
-                disks).
+  * interface_type: the type of the interface, currently supported:
+                    'network', 'bridge', 'vdpa', 'mcast', 'server', 'client', 'null', 'vds',
+                    defaults to 'network' if unset.
+  * mac:            MAC address of the interface. Without a mac key, a random
+                    address will be assigned by libvirt. The MAC address should
+                    start with 52:54:00.
+  * source:         Hash of the source (network/bridge to attach to) (optional)
+                    this will translate to keyX = valueX for all key value pairs
+                    in the hash added as attributes to the source tag in the resulting XML
+  * type:           Type of network card. Defaults to 'virtio'.
+  * boot_order:     Integer starting at 1 for the highest priority (shared with
+                    disks).
+  Deprecated keys:
+  * network:        libvirt network to attach to (optional, depracated, use source).
+                    instead of this parameter, use source = { '[network|bridge]' => NETWORK }
+  * portgroup:      portgroup to attach to (optional, deprecated, use source).
+                    instead of this parameter, use source = { '[network|bridge]' => NETWORK, 'portgroup' => 'GROUP }
+
+Hint: if a special configuration is not possible using this parameter, you can use the
+      $devices or $additionadevices parameter which make any configuration libvirt supports possible
 
 Default value: `[]`
 
@@ -910,6 +925,7 @@ this parameter is merged with the choosen profile,
 to generate the final configuration.
 Defaults to {} which does not change the profile.
 see also libvirt::profiles for how to use profiles
+Hint: This parameters allows to configure disks/network interfaces also
 
 Default value: `{}`
 
@@ -920,6 +936,7 @@ Data type: `Hash[String[1],Libvirt::Domain::Device]`
 additional devices to attach to the vm
 Same format as $devices, but without merging.
 Defaults to {}
+Hint: This parameters allows to configure disks/network interfaces also
 
 Default value: `{}`
 
@@ -2095,11 +2112,13 @@ Alias of
 
 ```puppet
 Struct[{
-    type      => Optional[String[1]],
-    network   => String[1],
-    portgroup => Optional[String[1]],
-    mac       => Optional[String[1]],
-    filter    => Optional[Variant[
+    type           => Optional[String[1]],
+    interface_type => Optional[Enum['network','bridge', 'vdpa', 'mcast', 'server', 'client', 'null', 'vds']],
+    network        => Optional[String[1]],  # deprecated, do not use
+    source         => Optional[Hash[String[1],String[1]]],
+    portgroup      => Optional[String[1]],  # deprecated, do not use, use source hash instead
+    mac            => Optional[String[1]],
+    filter         => Optional[Variant[
         String[1],
         Struct[{
             filterref  => String[1],
@@ -2109,7 +2128,7 @@ Struct[{
             ]],
         }],
     ]],
-    boot_order => Optional[Integer],
+    boot_order     => Optional[Integer],
 }]
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -848,6 +848,8 @@ The hashes support the following keys:
   * source:         Hash of the source (network/bridge to attach to) (optional)
                     this will translate to keyX = valueX for all key value pairs
                     in the hash added as attributes to the source tag in the resulting XML
+  * address:        Hash of the address sub-element to decribe where the device is placed on the
+                    virtual bus presented to the guest.
   * type:           Type of network card. Defaults to 'virtio'.
   * boot_order:     Integer starting at 1 for the highest priority (shared with
                     disks).
@@ -2117,6 +2119,7 @@ Struct[{
     network        => Optional[String[1]],  # deprecated, do not use
     source         => Optional[Hash[String[1],String[1]]],
     portgroup      => Optional[String[1]],  # deprecated, do not use, use source hash instead
+    address        => Optional[Hash[String[1],String[1]]],
     mac            => Optional[String[1]],
     filter         => Optional[Variant[
         String[1],

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -64,6 +64,8 @@
 #     * source:         Hash of the source (network/bridge to attach to) (optional)
 #                       this will translate to keyX = valueX for all key value pairs
 #                       in the hash added as attributes to the source tag in the resulting XML
+#     * address:        Hash of the address sub-element to decribe where the device is placed on the
+#                       virtual bus presented to the guest.
 #     * type:           Type of network card. Defaults to 'virtio'.
 #     * boot_order:     Integer starting at 1 for the highest priority (shared with
 #                       disks).

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -48,6 +48,9 @@
 #                   See the libvirt domain XML documentation for all possible values.
 #    * boot_order:  Integer starting at 1 for the highest priority (shared with
 #                   interfaces).
+#
+#   Hint: if a special configuration is not possible using this parameter, you can use the
+#         $devices or $additionadevices parameter which make any configuration libvirt supports possible
 # @param interfaces
 #   Array of hashes defining the network interfaces of this domain. Defaults to
 #   no network interfaces.
@@ -69,6 +72,9 @@
 #                       instead of this parameter, use source = { '[network|bridge]' => NETWORK }
 #     * portgroup:      portgroup to attach to (optional, deprecated, use source).
 #                       instead of this parameter, use source = { '[network|bridge]' => NETWORK, 'portgroup' => 'GROUP }
+#
+#   Hint: if a special configuration is not possible using this parameter, you can use the
+#         $devices or $additionadevices parameter which make any configuration libvirt supports possible
 # @param autostart
 #   Wheter the libvirt autostart flag should be set. Defaults to true. Autostart
 #   domains are started if the host is booted.
@@ -99,10 +105,12 @@
 #   to generate the final configuration.
 #   Defaults to {} which does not change the profile.
 #   see also libvirt::profiles for how to use profiles
+#   Hint: This parameters allows to configure disks/network interfaces also
 # @param additionaldevices
 #   additional devices to attach to the vm
 #   Same format as $devices, but without merging.
 #   Defaults to {}
+#   Hint: This parameters allows to configure disks/network interfaces also
 # @param replace
 #   set this to true if you like to replace existing VM
 #   configurations with puppet definitions (or if you change the config in puppet)

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -52,14 +52,23 @@
 #   Array of hashes defining the network interfaces of this domain. Defaults to
 #   no network interfaces.
 #   The hashes support the following keys:
-#     * mac:        MAC address of the interface. Without a mac key, a random
-#                   address will be assigned by libvirt. The MAC address should
-#                   start with 52:54:00.
-#     * network:    libvirt network to attach to (mandatory).
-#     * portgroup:  portgroup to attach to (optional).
-#     * type:       Type of network card. Defaults to 'virtio'.
-#     * boot_order: Integer starting at 1 for the highest priority (shared with
-#                   disks).
+#     * interface_type: the type of the interface, currently supported:
+#                       'network', 'bridge', 'vdpa', 'mcast', 'server', 'client', 'null', 'vds',
+#                       defaults to 'network' if unset.
+#     * mac:            MAC address of the interface. Without a mac key, a random
+#                       address will be assigned by libvirt. The MAC address should
+#                       start with 52:54:00.
+#     * source:         Hash of the source (network/bridge to attach to) (optional)
+#                       this will translate to keyX = valueX for all key value pairs
+#                       in the hash added as attributes to the source tag in the resulting XML
+#     * type:           Type of network card. Defaults to 'virtio'.
+#     * boot_order:     Integer starting at 1 for the highest priority (shared with
+#                       disks).
+#     Deprecated keys:
+#     * network:        libvirt network to attach to (optional, depracated, use source).
+#                       instead of this parameter, use source = { '[network|bridge]' => NETWORK }
+#     * portgroup:      portgroup to attach to (optional, deprecated, use source).
+#                       instead of this parameter, use source = { '[network|bridge]' => NETWORK, 'portgroup' => 'GROUP }
 # @param autostart
 #   Wheter the libvirt autostart flag should be set. Defaults to true. Autostart
 #   domains are started if the host is booted.

--- a/templates/domain/device_interface.epp
+++ b/templates/domain/device_interface.epp
@@ -1,7 +1,7 @@
 <%- |  Libvirt::Domain::Interface   $iface,
        String $boot,
     | -%>
-    <interface type='network'>
+    <interface type='<%= pick($iface['interface_type'],'network') %>'>
 <%- if 'mac' in $iface { -%>
       <mac address='<%= $iface['mac'] %>'/>
 <%- } -%>
@@ -22,7 +22,11 @@
       </filterref>
    <%- } -%>
 <%- } -%>
-      <source network='<%= $iface['network'] %>'<% if 'portgroup' in $iface { %> portgroup='<%= $iface['portgroup'] %>'<% } %>/>
+<%- if $iface['source'] { -%> 
+      <source <% $iface['source'].each |String $k, String $v| { %><%= $k %>='<%= $v %>' <% } %>/>
+<%- } elsif $iface['network'] { %><%# deprecated, do not use use source above -%>
+      <source <%= pick($iface['interface_type'],'network') %>='<%= $iface['network'] %>'<% if 'portgroup' in $iface { %> portgroup='<%= $iface['portgroup'] %>'<% } %>/>
+<%- } -%>
       <model type='<% if 'type' in $iface { %><%= $iface['type'] %><% }else{ %>virtio<% } %>'/>
 <%- if $boot == 'per-device' and 'boot_order' in $iface { -%>
       <boot order='<%= $iface['boot_order'] %>'/>

--- a/templates/domain/device_interface.epp
+++ b/templates/domain/device_interface.epp
@@ -27,6 +27,9 @@
 <%- } elsif $iface['network'] { %><%# deprecated, do not use use source above -%>
       <source <%= pick($iface['interface_type'],'network') %>='<%= $iface['network'] %>'<% if 'portgroup' in $iface { %> portgroup='<%= $iface['portgroup'] %>'<% } %>/>
 <%- } -%>
+<%- if $iface['address'] { -%>
+      <address <% $iface['address'].each |String $k, String $v| { %><%= $k %>='<%= $v %>' <% } %>/>
+<%- } -%>
       <model type='<% if 'type' in $iface { %><%= $iface['type'] %><% }else{ %>virtio<% } %>'/>
 <%- if $boot == 'per-device' and 'boot_order' in $iface { -%>
       <boot order='<%= $iface['boot_order'] %>'/>

--- a/types/domain/interface.pp
+++ b/types/domain/interface.pp
@@ -1,10 +1,12 @@
 # A interface of a Domain
 type Libvirt::Domain::Interface = Struct[{
-    type      => Optional[String[1]],
-    network   => String[1],
-    portgroup => Optional[String[1]],
-    mac       => Optional[String[1]],
-    filter    => Optional[Variant[
+    type           => Optional[String[1]],
+    interface_type => Optional[Enum['network','bridge', 'vdpa', 'mcast', 'server', 'client', 'null', 'vds']],
+    network        => Optional[String[1]],  # deprecated, do not use
+    source         => Optional[Hash[String[1],String[1]]],
+    portgroup      => Optional[String[1]],  # deprecated, do not use, use source hash instead
+    mac            => Optional[String[1]],
+    filter         => Optional[Variant[
         String[1],
         Struct[{
             filterref  => String[1],
@@ -14,5 +16,5 @@ type Libvirt::Domain::Interface = Struct[{
             ]],
         }],
     ]],
-    boot_order => Optional[Integer],
+    boot_order     => Optional[Integer],
 }]

--- a/types/domain/interface.pp
+++ b/types/domain/interface.pp
@@ -5,6 +5,7 @@ type Libvirt::Domain::Interface = Struct[{
     network        => Optional[String[1]],  # deprecated, do not use
     source         => Optional[Hash[String[1],String[1]]],
     portgroup      => Optional[String[1]],  # deprecated, do not use, use source hash instead
+    address        => Optional[Hash[String[1],String[1]]],
     mac            => Optional[String[1]],
     filter         => Optional[Variant[
         String[1],


### PR DESCRIPTION
This pull request adds addional network types for VM's. This is based on the idea of the pullrequest #81 which it superseeds. 

This also includes adaptation of README (from #81) and a deprecation of the network parameter in favor of a new source hash (the network parameter still works and will eventually deprecated on next major release).
