### PR TITLE
Fix JRuby stack overflow in XML sorting helpers

### DIFF
--- a/lib/puppet_x/libvirt/rexml_sorted_attributes.rb
+++ b/lib/puppet_x/libvirt/rexml_sorted_attributes.rb
@@ -5,7 +5,11 @@ require 'rexml/document'
 # replace each_attribute with a sorted version
 class REXML::Attributes
   alias xx_each_attribute each_attribute
-  def each_attribute(&b)
-    to_enum(:xx_each_attribute).sort_by { |x| x.name }.each(&b)
+  def each_attribute_sorted(&b)
+    return enum_for(:each_attribute_sorted) unless block_given?
+    # Materialize to a plain array first (avoid nested enumerators), then sort by a flat String key.
+    attrs = to_enum(:xx_each_attribute).to_a
+    attrs.sort! { |a, b| a.name.to_s <=> b.name.to_s }
+    attrs.each(&b)
   end
 end

--- a/lib/puppet_x/libvirt/sort_elements.rb
+++ b/lib/puppet_x/libvirt/sort_elements.rb
@@ -6,8 +6,11 @@
 #
 def recursive_sort(elements)
   if elements.has_elements?
-    el = elements.elements.sort_by(&:name)
-    el.each do |element|
+    # Materialize first and sort by a flat String key 
+    # to avoid JRuby Enumerable.sort_by recursion
+    els = elements.elements.to_a
+    els.sort! { |a, b| a.name.to_s <=> b.name.to_s }
+    els.each do |element|
       # remove text with only space
       elements.elements.delete(element)
       element.each do |child|


### PR DESCRIPTION
Replace Enumerable#sort_by with array materialization + String comparator in recursive_sort() and REXMLSortedAttributes to prevent infinite recursion under JRuby on Puppetserver (observed in libvirt::domain resource catalog compilation).