### PR TITLE
fix domconf merge

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -187,12 +187,12 @@ define libvirt::domain (
   include libvirt
   include libvirt::profiles
 
-  $devices_real  = libvirt::get_merged_profile($libvirt::profiles::devices, $devices_profile) + $devices
+  $devices_real  = deep_merge(libvirt::get_merged_profile($libvirt::profiles::devices, $devices_profile), $devices)
 
   if $boot == 'per-device' {
-    $domconf_real  = libvirt::get_merged_profile($libvirt::profiles::domconf, $dom_profile) + $domconf
+    $domconf_real  = deep_merge(libvirt::get_merged_profile($libvirt::profiles::domconf, $dom_profile), $domconf)
   } else {
-    $_domconf = libvirt::get_merged_profile($libvirt::profiles::domconf, $dom_profile) + $domconf
+    $_domconf = deep_merge(libvirt::get_merged_profile($libvirt::profiles::domconf, $dom_profile), $domconf)
     $domconf_real = deep_merge($_domconf, { 'os' => { 'boot' => { 'attrs' => { 'dev' => $boot } } } })
   }
 


### PR DESCRIPTION
here is a problem with merging nested hashes using +: they are not merged deeply.

Example:
```
$h1 = {  'a' => {  'x' => 1,  'y' => 2  },  'b' => 1 }
$h2 = {  'a' => {  'y' => 99 } }
$h3 = $h1 + $h2
'''
Result:
```
{ a => { y => 99 }, b => 1 }
```
As a result, we cannot correctly merge the domain domconf with the profile domconf.
The solution is to use deep_merge() instead.